### PR TITLE
Sp cert and key files have an expected name.

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -22,8 +22,8 @@ def test_shibd_process(host):
     'idp-metadata.xml',
     'shibboleth2.xml',
     'attribute-map.xml',
-    'shib-sp.crt',
-    'shib-sp.key'
+    'sp-cert.pem',
+    'sp-key.pem'
     ])
 def test_idp_config_files(host, f):
     remote_file = host.file('/etc/shibboleth/' + f)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,14 +32,18 @@
 
 - name: Add shibboleth cert and key
   copy:
-    src: "{{ item.file }}"
-    dest: "/etc/shibboleth/{{ item.file }}"
+    src: "{{ item.src }}"
+    dest: "/etc/shibboleth/{{ item.dest }}"
     owner: shibd
     group: shibd
     mode: "{{ item.mode }}"
   with_items:
-    - {file: "{{ shibboleth_sp_certificate_file }}", mode: "u=rw,g=r,o=r" }
-    - {file: "{{ shibboleth_sp_key_file }}", mode: "u=rw" }
+    - src: "{{ shibboleth_sp_certificate_file }}"
+      dest: "sp-cert.pem"
+      mode: "u=rw,g=r,o=r"
+    - src: "{{ shibboleth_sp_key_file }}"
+      dest: "sp-key.pem"
+      mode: "u=rw"
   notify:
     - restart shibd
     - restart httpd


### PR DESCRIPTION
Use the expected name, no matter the local source filename.