### PR TITLE
Fix shib config points to incorrect idp-metadata.

### DIFF
--- a/templates/shibboleth2.xml.j2
+++ b/templates/shibboleth2.xml.j2
@@ -86,7 +86,7 @@
 
         <!-- Example of locally maintained metadata. -->
 
-        <MetadataProvider type="XML" validate="true" path="/etc/shibboleth/idp-metadata.xml"/>
+        <MetadataProvider type="XML" validate="true" path="/etc/shibboleth/{{ shibboleth_sp_idp_metadata_file }}"/>
 
         <!-- Map to extract attributes from SAML assertions. -->
         <AttributeExtractor type="XML" validate="true"  path="attribute-map.xml"/>


### PR DESCRIPTION
The ipb-metadata file is harcoded in the configuration instead of using the
file that is defined in the shibboleth_sp_idp_metadata_file variable.